### PR TITLE
Remove `#![feature(try_blocks)]` from macro crate

### DIFF
--- a/lox-macros/src/lib.rs
+++ b/lox-macros/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit="256"]
-#![feature(try_blocks)]
 
 extern crate proc_macro;
 


### PR DESCRIPTION
It's unused