### PR TITLE
Fix `unexpected_cfgs` warning.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,6 @@ pub trait Handle: 'static + Copy + fmt::Debug + Eq + Ord {
         #[cfg(any(
             all(target_pointer_width = "32", feature = "large-handle"),
             target_pointer_width = "16",
-            target_pointer_width = "8",
         ))]
         debug_assert!(self.idx() <= usize::max_value() as hsize);
 


### PR DESCRIPTION
`target_pointer_width` can have values 16, 32, or 64, so don't compare against 8. This results in a warning due to the `unexpected_cfgs` lint.