### PR TITLE
Fix `clippy::legacy-numeric-constants` lints.

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -390,24 +390,24 @@ macro_rules! impl_cast {
     // three different cases: pos, neg and both. Which just say at what ends
     // the clamping might occur.
     (@imp $src:ident -> $dst:ident : Clamping.pos; $v:ident) => {
-        if $v > $dst::max_value() as $src {
-            $dst::max_value()
+        if $v > $dst::MAX as $src {
+            $dst::MAX
         } else {
             $v as $dst
         }
     };
     (@imp $src:ident -> $dst:ident : Clamping.neg; $v:ident) => {
-        if $v < $dst::min_value() as $src {
-            $dst::min_value()
+        if $v < $dst::MIN as $src {
+            $dst::MIN
         } else {
             $v as $dst
         }
     };
     (@imp $src:ident -> $dst:ident : Clamping.both; $v:ident) => {
-        if $v > $dst::max_value() as $src {
-            $dst::max_value()
-        } else if $v < $dst::min_value() as $src {
-            $dst::min_value()
+        if $v > $dst::MAX as $src {
+            $dst::MAX
+        } else if $v < $dst::MIN as $src {
+            $dst::MIN
         } else {
             $v as $dst
         }

--- a/src/core/checked.rs
+++ b/src/core/checked.rs
@@ -50,10 +50,10 @@ impl<H: Handle> Checked<H> {
 
 impl<H: Handle> optional::Noned for Checked<H> {
     fn is_none(&self) -> bool {
-        self.0.idx() == hsize::max_value()
+        self.0.idx() == hsize::MAX
     }
     fn get_none() -> Self {
-        Self(H::new(hsize::max_value()))
+        Self(H::new(hsize::MAX))
     }
 }
 impl<H: Handle> optional::OptEq for Checked<H> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ type HsizeImpl = u64;
 /// strong typing.
 pub trait Handle: 'static + Copy + fmt::Debug + Eq + Ord {
     /// Create a handle from the given index. The index must not be
-    /// `hsize::max_value()` as this value is reserved!
+    /// `hsize::MAX` as this value is reserved!
     fn new(idx: hsize) -> Self;
 
     /// Return the index of the current handle.
@@ -362,7 +362,7 @@ pub trait Handle: 'static + Copy + fmt::Debug + Eq + Ord {
     fn from_usize(raw: usize) -> Self {
         // If `usize` is bigger than `hsize`, we assert that the value is fine.
         #[cfg(all(target_pointer_width = "64", not(feature = "large-handle")))]
-        debug_assert!(raw <= hsize::max_value() as usize);
+        debug_assert!(raw <= hsize::MAX as usize);
 
         Self::new(raw as hsize)
     }
@@ -382,7 +382,7 @@ pub trait Handle: 'static + Copy + fmt::Debug + Eq + Ord {
             target_pointer_width = "16",
             target_pointer_width = "8",
         ))]
-        debug_assert!(self.idx() <= usize::max_value() as hsize);
+        debug_assert!(self.idx() <= usize::MAX as hsize);
 
         self.idx() as usize
     }

--- a/src/util/prop.rs
+++ b/src/util/prop.rs
@@ -176,12 +176,12 @@ impl<T: PrimitiveNum> Vec3Like for [T; 3] {
 /// Types that can be used as a color channel.
 ///
 /// Implemented for `u8`, `u16`, `u32`, `f32` and `f64`. For integer types, the
-/// whole range is used (0 to `T::max_value()`) while for floats, the values
+/// whole range is used (0 to `T::MAX`) while for floats, the values
 /// are always between 0 and 1.
 pub trait PrimitiveColorChannel: PrimitiveNum {
     /// The value representing maximum intensity.
     ///
-    /// `T::max_value()` for integer, `1.0` for floats. The minimum intensity
+    /// `T::MAX` for integer, `1.0` for floats. The minimum intensity
     /// is always 0.
     const MAX_INTENSITY: Self;
 
@@ -189,7 +189,7 @@ pub trait PrimitiveColorChannel: PrimitiveNum {
     /// values.
     ///
     /// This is not a simple `as` cast or even `cast::lossy`. For example,
-    /// `255u8` becomes `1.0f32` or `u16::max_value()`. These casts are not
+    /// `255u8` becomes `1.0f32` or `u16::MAX`. These casts are not
     /// lossless, but might round the value a bit (like casting rigor
     /// `AllowRounding`).
     fn color_cast_from<SrcT: PrimitiveColorChannel>(src: SrcT) -> Self {
@@ -204,13 +204,13 @@ pub trait PrimitiveColorChannel: PrimitiveNum {
 }
 
 impl PrimitiveColorChannel for u8 {
-    const MAX_INTENSITY: Self = u8::max_value();
+    const MAX_INTENSITY: Self = u8::MAX;
 }
 impl PrimitiveColorChannel for u16 {
-    const MAX_INTENSITY: Self = u16::max_value();
+    const MAX_INTENSITY: Self = u16::MAX;
 }
 impl PrimitiveColorChannel for u32 {
-    const MAX_INTENSITY: Self = u32::max_value();
+    const MAX_INTENSITY: Self = u32::MAX;
 }
 impl PrimitiveColorChannel for f32 {
     const MAX_INTENSITY: Self = 1.0;
@@ -368,55 +368,55 @@ mod tests {
     #[test]
     fn color_cast() {
         assert_eq!(u8::color_cast_from(0u8), 0);
-        assert_eq!(u8::color_cast_from(u8::max_value()), 255);
+        assert_eq!(u8::color_cast_from(u8::MAX), 255);
         assert_eq!(u8::color_cast_from(0u16), 0);
-        assert_eq!(u8::color_cast_from(u16::max_value()), 255);
+        assert_eq!(u8::color_cast_from(u16::MAX), 255);
         assert_eq!(u8::color_cast_from(0u32), 0);
-        assert_eq!(u8::color_cast_from(u32::max_value()), 255);
+        assert_eq!(u8::color_cast_from(u32::MAX), 255);
         assert_eq!(u8::color_cast_from(0.0f32), 0);
         assert_eq!(u8::color_cast_from(1.0f32), 255);
         assert_eq!(u8::color_cast_from(0.0f64), 0);
         assert_eq!(u8::color_cast_from(1.0f64), 255);
 
         assert_eq!(u16::color_cast_from(0u8), 0);
-        assert_eq!(u16::color_cast_from(u8::max_value()), u16::max_value());
+        assert_eq!(u16::color_cast_from(u8::MAX), u16::max_value());
         assert_eq!(u16::color_cast_from(0u16), 0);
-        assert_eq!(u16::color_cast_from(u16::max_value()), u16::max_value());
+        assert_eq!(u16::color_cast_from(u16::MAX), u16::max_value());
         assert_eq!(u16::color_cast_from(0u32), 0);
-        assert_eq!(u16::color_cast_from(u32::max_value()), u16::max_value());
+        assert_eq!(u16::color_cast_from(u32::MAX), u16::max_value());
         assert_eq!(u16::color_cast_from(0.0f32), 0);
-        assert_eq!(u16::color_cast_from(1.0f32), u16::max_value());
+        assert_eq!(u16::color_cast_from(1.0f32), u16::MAX);
         assert_eq!(u16::color_cast_from(0.0f64), 0);
-        assert_eq!(u16::color_cast_from(1.0f64), u16::max_value());
+        assert_eq!(u16::color_cast_from(1.0f64), u16::MAX);
 
         assert_eq!(u32::color_cast_from(0u8), 0);
-        assert_eq!(u32::color_cast_from(u8::max_value()), u32::max_value());
+        assert_eq!(u32::color_cast_from(u8::MAX), u32::max_value());
         assert_eq!(u32::color_cast_from(0u16), 0);
-        assert_eq!(u32::color_cast_from(u16::max_value()), u32::max_value());
+        assert_eq!(u32::color_cast_from(u16::MAX), u32::max_value());
         assert_eq!(u32::color_cast_from(0u32), 0);
-        assert_eq!(u32::color_cast_from(u32::max_value()), u32::max_value());
+        assert_eq!(u32::color_cast_from(u32::MAX), u32::max_value());
         assert_eq!(u32::color_cast_from(0.0f32), 0);
-        assert_eq!(u32::color_cast_from(1.0f32), u32::max_value());
+        assert_eq!(u32::color_cast_from(1.0f32), u32::MAX);
         assert_eq!(u32::color_cast_from(0.0f64), 0);
-        assert_eq!(u32::color_cast_from(1.0f64), u32::max_value());
+        assert_eq!(u32::color_cast_from(1.0f64), u32::MAX);
 
         assert_eq!(f32::color_cast_from(0u8), 0.0);
-        assert_eq!(f32::color_cast_from(u8::max_value()), 1.0);
+        assert_eq!(f32::color_cast_from(u8::MAX), 1.0);
         assert_eq!(f32::color_cast_from(0u16), 0.0);
-        assert_eq!(f32::color_cast_from(u16::max_value()), 1.0);
+        assert_eq!(f32::color_cast_from(u16::MAX), 1.0);
         assert_eq!(f32::color_cast_from(0u32), 0.0);
-        assert_eq!(f32::color_cast_from(u32::max_value()), 1.0);
+        assert_eq!(f32::color_cast_from(u32::MAX), 1.0);
         assert_eq!(f32::color_cast_from(0.0f32), 0.0);
         assert_eq!(f32::color_cast_from(1.0f32), 1.0);
         assert_eq!(f32::color_cast_from(0.0f64), 0.0);
         assert_eq!(f32::color_cast_from(1.0f64), 1.0);
 
         assert_eq!(f64::color_cast_from(0u8), 0.0);
-        assert_eq!(f64::color_cast_from(u8::max_value()), 1.0);
+        assert_eq!(f64::color_cast_from(u8::MAX), 1.0);
         assert_eq!(f64::color_cast_from(0u16), 0.0);
-        assert_eq!(f64::color_cast_from(u16::max_value()), 1.0);
+        assert_eq!(f64::color_cast_from(u16::MAX), 1.0);
         assert_eq!(f64::color_cast_from(0u32), 0.0);
-        assert_eq!(f64::color_cast_from(u32::max_value()), 1.0);
+        assert_eq!(f64::color_cast_from(u32::MAX), 1.0);
         assert_eq!(f64::color_cast_from(0.0f32), 0.0);
         assert_eq!(f64::color_cast_from(1.0f32), 1.0);
         assert_eq!(f64::color_cast_from(0.0f64), 0.0);


### PR DESCRIPTION
These are slated to be deprecated in the future in favor of the associated constants.